### PR TITLE
`actix` feature fixes & missing `pub` on important types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "surreal-simple-client"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT"
 description = "An async Rust client for SurrealDB's RPC endpoint"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
-mod errors;
 mod message;
 mod response;
-mod rpc;
 mod surreal_client;
 
 pub use message::SurrealMessage;
 pub use response::SurrealResponse;
 pub use surreal_client::SurrealClient;
+pub mod errors;
+pub mod rpc;

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -53,17 +53,17 @@ impl Display for RpcChannelError {
 #[cfg(feature = "actix")]
 impl actix_web::ResponseError for RpcChannelError {
   fn error_response(&self) -> actix_web::HttpResponse<actix_web::body::BoxBody> {
-    HttpResponse::build(self.status_code())
-      .insert_header(ContentType::html())
+    actix_web::HttpResponse::build(self.status_code())
+      .insert_header(actix_web::http::header::ContentType::html())
       .body(match self {
-        RpcChannelError::SurrealBodyParsingError { inner } => {
-          println!("Failed to parse results from the database: {inner}");
+        RpcChannelError::SurrealBodyParsingError { inner: _ } => {
           "Failed to parse results from the database"
         }
         RpcChannelError::SocketError { inner: _ } => "RPC socket failure",
         RpcChannelError::SurrealQueryError { inner: _ } => {
           "Incorrect query was sent to the database"
         }
+        RpcChannelError::OneshotError { inner: _ } => "SPSC channel failure",
       })
   }
 }


### PR DESCRIPTION
- fixed compilation errors coming from the actix feature's code
- made some missing types public, such as the `RpcResult` type and the error types