### PR TITLE
feat: simplify RpcChannelError type conversion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ nanoid = "0.4.0"
 
 # for automatic conversions to actix responses on RPC errors
 actix-web = { version = "4", optional = true }
+thiserror = "1.0.37"
 
 [features]
 actix = ["dep:actix-web"]

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -2,12 +2,13 @@ use std::fmt::Display;
 
 use tokio::sync::oneshot;
 use tokio_tungstenite::tungstenite;
+use thiserror::Error;
 
 use crate::errors::SurrealError;
 
 pub type RpcResult<T> = Result<T, RpcChannelError>;
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum RpcChannelError {
   SurrealBodyParsingError { inner: serde_json::Error },
   SocketError { inner: tungstenite::Error },


### PR DESCRIPTION
Adds thiserror::Error derive macro to RpcChannelError to make have it implement std::error::Error and therefore easier to convert the error with crates like thiserror and anyhow.